### PR TITLE
Use tilde in version spec

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": ">=5.3.7",
         "ircmaxell/password-compat": "1.*",
-        "wp-cli/php-cli-tools": "v0.9.4"
+        "wp-cli/php-cli-tools": "~0.9.4"
     },
     "require-dev": {
         "league/phpunit-coverage-listener": "~1.1",


### PR DESCRIPTION
Was getting an error when trying to install package, with composer
returning that it could not find a version of "wp-cli" that matched
"v0.9.4". Upon checking packagist, found that this version was patched
and now called "v0.9.4-patch46". Adding the tilde in front of the
current version will allow this to download properly and if patched
again, remain working seamlessly since it sets "v0.9.4" to a minimum
allowable version.
