### PR TITLE
Remove custom salt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,11 @@ if ($result->isValid()) {
 ```
 
 If your application requires options other than the `password_hash` defaults,
-you can set both the `salt` and `cost` options with `PasswordValidator::setOptions()`.
+you can set the `cost` option with `PasswordValidator::setOptions()`.
 
 ``` php
 $options = array(
-    'salt' => 'SettingYourOwnSaltIsNotTheBestIdea',
-    'cost' => 11,
+    'cost' => 11
 );
 $validator->setOptions($options);
 ```


### PR DESCRIPTION
The ability to provide custom salts will be removed in future versions of PHP, as discussed here:

https://marc.info/?t=142782791400003&r=1&w=2

Even though password_hash() and your library currently support this, I suggest removing option from the usage example, because people _will_ use it incorrectly and create much worse salts than it does by default.