### PR TITLE
Update gitignore to ignore vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 composer.lock
+vendor/


### PR DESCRIPTION
When I did `composer install` to run unit tests, Git wanted to add the vendor folder.