### PR TITLE
RFC: fix PHP7 warning with "force rehash" approach

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,4 @@ before_script:
   - composer self-update
   - composer install --prefer-dist
 
-script: phpunit -c travis.phpunit.xml
-
-after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover /tmp/jeremykendall/password-validator/coverage.xml
+script: phpunit -c phpunit.xml.dist

--- a/src/JeremyKendall/Password/Decorator/AbstractDecorator.php
+++ b/src/JeremyKendall/Password/Decorator/AbstractDecorator.php
@@ -64,11 +64,11 @@ abstract class AbstractDecorator implements PasswordValidatorInterface
         $this->validator->setOptions($options);
     }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function setForceRehash($forceRehash)
-	{
-		$this->validator->setForceRehash($forceRehash);
-	}
+    /**
+     * {@inheritDoc}
+     */
+    public function setForceRehash($forceRehash)
+    {
+        $this->validator->setForceRehash($forceRehash);
+    }
 }

--- a/src/JeremyKendall/Password/Decorator/AbstractDecorator.php
+++ b/src/JeremyKendall/Password/Decorator/AbstractDecorator.php
@@ -63,4 +63,12 @@ abstract class AbstractDecorator implements PasswordValidatorInterface
     {
         $this->validator->setOptions($options);
     }
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setForceRehash($forceRehash)
+	{
+		$this->validator->setForceRehash($forceRehash);
+	}
 }

--- a/src/JeremyKendall/Password/Decorator/UpgradeDecorator.php
+++ b/src/JeremyKendall/Password/Decorator/UpgradeDecorator.php
@@ -51,7 +51,7 @@ class UpgradeDecorator extends AbstractDecorator
             $passwordHash = password_hash($password, PASSWORD_DEFAULT, array(
                 'cost' => 4,
             ));
-			$this->setForceRehash(true);
+            $this->setForceRehash(true);
         }
 
         return $this->validator->isValid($password, $passwordHash, $legacySalt, $identity);

--- a/src/JeremyKendall/Password/Decorator/UpgradeDecorator.php
+++ b/src/JeremyKendall/Password/Decorator/UpgradeDecorator.php
@@ -50,7 +50,6 @@ class UpgradeDecorator extends AbstractDecorator
         if ($isValid === true) {
             $passwordHash = password_hash($password, PASSWORD_DEFAULT, array(
                 'cost' => 4,
-                'salt' => 'CostAndSaltForceRehash',
             ));
         }
 

--- a/src/JeremyKendall/Password/Decorator/UpgradeDecorator.php
+++ b/src/JeremyKendall/Password/Decorator/UpgradeDecorator.php
@@ -51,6 +51,7 @@ class UpgradeDecorator extends AbstractDecorator
             $passwordHash = password_hash($password, PASSWORD_DEFAULT, array(
                 'cost' => 4,
             ));
+			$this->setForceRehash(true);
         }
 
         return $this->validator->isValid($password, $passwordHash, $legacySalt, $identity);

--- a/src/JeremyKendall/Password/PasswordValidator.php
+++ b/src/JeremyKendall/Password/PasswordValidator.php
@@ -23,17 +23,17 @@ class PasswordValidator implements PasswordValidatorInterface
      */
     protected $options = array();
 
-	/**
+    /**
      * @var array Result info
      */
     protected $resultInfo = array();
 
-	/**
-	 * @var bool Whether or not to force a rehash
-	 */
-	protected $forceRehash = false;
+    /**
+     * @var bool Whether or not to force a rehash
+     */
+    protected $forceRehash = false;
 
-	/**
+    /**
      * {@inheritDoc}
      */
     public function isValid($password, $passwordHash, $legacySalt = null, $identity = null)
@@ -45,9 +45,9 @@ class PasswordValidator implements PasswordValidatorInterface
 
         $isValid = password_verify($password, $passwordHash);
 
-		$needsRehash = $this->passwordNeedsRehash($passwordHash);
+        $needsRehash = $this->passwordNeedsRehash($passwordHash);
 
-		if ($isValid === true) {
+        if ($isValid === true) {
             $this->resultInfo['code'] = ValidationResult::SUCCESS;
         }
 
@@ -61,7 +61,7 @@ class PasswordValidator implements PasswordValidatorInterface
         );
     }
 
-	/**
+    /**
      * {@inheritDoc}
      */
     public function rehash($password)
@@ -87,7 +87,7 @@ class PasswordValidator implements PasswordValidatorInterface
         return $hash;
     }
 
-	/**
+    /**
      * {@inheritDoc}
      */
     public function getOptions()
@@ -95,7 +95,7 @@ class PasswordValidator implements PasswordValidatorInterface
         return $this->options;
     }
 
-	/**
+    /**
      * {@inheritDoc}
      */
     public function setOptions(array $options)
@@ -103,31 +103,31 @@ class PasswordValidator implements PasswordValidatorInterface
         $this->options = $options;
     }
 
-	/**
-	 * @param bool $forceRehash
-	 */
-	public function setForceRehash($forceRehash)
-	{
-		$this->forceRehash = (bool)$forceRehash;
-	}
+    /**
+     * @param bool $forceRehash
+     */
+    public function setForceRehash($forceRehash)
+    {
+        $this->forceRehash = (bool)$forceRehash;
+    }
 
-	/**
-	 * @return bool
-	 */
-	public function getForceRehash()
-	{
-		return $this->forceRehash;
-	}
+    /**
+     * @return bool
+     */
+    public function getForceRehash()
+    {
+        return $this->forceRehash;
+    }
 
-	/**
-	 * @param $passwordHash
-	 * @return bool|string
-	 */
-	protected function passwordNeedsRehash($passwordHash)
-	{
-		if (password_needs_rehash($passwordHash, PASSWORD_DEFAULT, $this->getOptions())) {
-			return true;
-		}
-		return $this->getForceRehash();
-	}
+    /**
+     * @param $passwordHash
+     * @return bool|string
+     */
+    protected function passwordNeedsRehash($passwordHash)
+    {
+        if (password_needs_rehash($passwordHash, PASSWORD_DEFAULT, $this->getOptions())) {
+            return true;
+        }
+        return $this->getForceRehash();
+    }
 }

--- a/src/JeremyKendall/Password/PasswordValidator.php
+++ b/src/JeremyKendall/Password/PasswordValidator.php
@@ -23,12 +23,17 @@ class PasswordValidator implements PasswordValidatorInterface
      */
     protected $options = array();
 
-    /**
+	/**
      * @var array Result info
      */
     protected $resultInfo = array();
 
-    /**
+	/**
+	 * @var bool Whether or not to force a rehash
+	 */
+	protected $forceRehash = false;
+
+	/**
      * {@inheritDoc}
      */
     public function isValid($password, $passwordHash, $legacySalt = null, $identity = null)
@@ -40,13 +45,9 @@ class PasswordValidator implements PasswordValidatorInterface
 
         $isValid = password_verify($password, $passwordHash);
 
-        $needsRehash = password_needs_rehash(
-            $passwordHash, 
-            PASSWORD_DEFAULT, 
-            $this->getOptions()
-        );
+		$needsRehash = $this->passwordNeedsRehash($passwordHash);
 
-        if ($isValid === true) {
+		if ($isValid === true) {
             $this->resultInfo['code'] = ValidationResult::SUCCESS;
         }
 
@@ -60,7 +61,7 @@ class PasswordValidator implements PasswordValidatorInterface
         );
     }
 
-    /**
+	/**
      * {@inheritDoc}
      */
     public function rehash($password)
@@ -86,7 +87,7 @@ class PasswordValidator implements PasswordValidatorInterface
         return $hash;
     }
 
-    /**
+	/**
      * {@inheritDoc}
      */
     public function getOptions()
@@ -94,11 +95,28 @@ class PasswordValidator implements PasswordValidatorInterface
         return $this->options;
     }
 
-    /**
+	/**
      * {@inheritDoc}
      */
     public function setOptions(array $options)
     {
         $this->options = $options;
     }
+
+	public function setForceRehash($forceRehash)
+	{
+		$this->forceRehash = $forceRehash;
+	}
+
+	/**
+	 * @param $passwordHash
+	 * @return bool|string
+	 */
+	protected function passwordNeedsRehash($passwordHash)
+	{
+		if (password_needs_rehash($passwordHash, PASSWORD_DEFAULT, $this->getOptions())) {
+			return true;
+		}
+		return $this->forceRehash;
+	}
 }

--- a/src/JeremyKendall/Password/PasswordValidator.php
+++ b/src/JeremyKendall/Password/PasswordValidator.php
@@ -103,9 +103,20 @@ class PasswordValidator implements PasswordValidatorInterface
         $this->options = $options;
     }
 
+	/**
+	 * @param bool $forceRehash
+	 */
 	public function setForceRehash($forceRehash)
 	{
-		$this->forceRehash = $forceRehash;
+		$this->forceRehash = (bool)$forceRehash;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function getForceRehash()
+	{
+		return $this->forceRehash;
 	}
 
 	/**
@@ -117,6 +128,6 @@ class PasswordValidator implements PasswordValidatorInterface
 		if (password_needs_rehash($passwordHash, PASSWORD_DEFAULT, $this->getOptions())) {
 			return true;
 		}
-		return $this->forceRehash;
+		return $this->getForceRehash();
 	}
 }

--- a/src/JeremyKendall/Password/PasswordValidatorInterface.php
+++ b/src/JeremyKendall/Password/PasswordValidatorInterface.php
@@ -53,11 +53,11 @@ interface PasswordValidatorInterface
      */
     public function getOptions();
 
-	/**
-	 * Tell PasswordValidator to force a rehash
-	 * Example: used by UpgradeDecorator to ensure that the rehashed legacy hash is correctly re-hashed
-	 *
-	 * @param bool $forceRehash
-	 */
-	public function setForceRehash($forceRehash);
+    /**
+     * Tell PasswordValidator to force a rehash
+     * Example: used by UpgradeDecorator to ensure that the rehashed legacy hash is correctly re-hashed
+     *
+     * @param bool $forceRehash
+     */
+    public function setForceRehash($forceRehash);
 }

--- a/src/JeremyKendall/Password/PasswordValidatorInterface.php
+++ b/src/JeremyKendall/Password/PasswordValidatorInterface.php
@@ -52,4 +52,12 @@ interface PasswordValidatorInterface
      * @return array password_hash options
      */
     public function getOptions();
+
+	/**
+	 * Tell PasswordValidator to force a rehash
+	 * Example: used by UpgradeDecorator to ensure that the rehashed legacy hash is correctly re-hashed
+	 *
+	 * @param bool $forceRehash
+	 */
+	public function setForceRehash($forceRehash);
 }

--- a/tests/JeremyKendall/Password/Tests/Decorator/IntegrationTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/IntegrationTest.php
@@ -91,4 +91,24 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertStringStartsWith('$2y$10$', $result->getPassword());
     }
+
+	public function testLegacyPasswordIsValidUpgradedRehashedWhenClientCodeUsesSameParametersAsUpgradeDecorator()
+	{
+		$validator = new UpgradeDecorator(
+			new PasswordValidator(),
+			$this->callback
+		);
+		$password = 'password';
+		$hash = hash('sha512', $password);
+
+		$validator->setOptions(['cost' => 4]);
+
+		$result = $validator->isValid($password, $hash);
+
+		$this->assertTrue($result->isValid());
+		$this->assertEquals(
+			ValidationResult::SUCCESS_PASSWORD_REHASHED,
+			$result->getCode()
+		);
+	}
 }

--- a/tests/JeremyKendall/Password/Tests/Decorator/IntegrationTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/IntegrationTest.php
@@ -101,7 +101,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 		$password = 'password';
 		$hash = hash('sha512', $password);
 
-		$validator->setOptions(['cost' => 4]);
+		$validator->setOptions(array('cost' => 4));
 
 		$result = $validator->isValid($password, $hash);
 

--- a/tests/JeremyKendall/Password/Tests/Decorator/IntegrationTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/IntegrationTest.php
@@ -92,23 +92,23 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertStringStartsWith('$2y$10$', $result->getPassword());
     }
 
-	public function testLegacyPasswordIsValidUpgradedRehashedWhenClientCodeUsesSameParametersAsUpgradeDecorator()
-	{
-		$validator = new UpgradeDecorator(
-			new PasswordValidator(),
-			$this->callback
-		);
-		$password = 'password';
-		$hash = hash('sha512', $password);
+    public function testLegacyPasswordIsValidUpgradedRehashedWhenClientCodeUsesSameParametersAsUpgradeDecorator()
+    {
+        $validator = new UpgradeDecorator(
+            new PasswordValidator(),
+            $this->callback
+        );
+        $password = 'password';
+        $hash = hash('sha512', $password);
 
-		$validator->setOptions(array('cost' => 4));
+        $validator->setOptions(array('cost' => 4));
 
-		$result = $validator->isValid($password, $hash);
+        $result = $validator->isValid($password, $hash);
 
-		$this->assertTrue($result->isValid());
-		$this->assertEquals(
-			ValidationResult::SUCCESS_PASSWORD_REHASHED,
-			$result->getCode()
-		);
-	}
+        $this->assertTrue($result->isValid());
+        $this->assertEquals(
+            ValidationResult::SUCCESS_PASSWORD_REHASHED,
+            $result->getCode()
+        );
+    }
 }

--- a/tests/JeremyKendall/Password/Tests/Decorator/KarptoniteRehashUpgradeDecoratorTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/KarptoniteRehashUpgradeDecoratorTest.php
@@ -67,14 +67,6 @@ class KarptoniteRehashUpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
 
     public function testRehashingPasswordHashesScenarioCredentialIsValid()
     {
-        $upgradeValidatorRehash = password_hash(
-            $this->plainTextPassword,
-            PASSWORD_DEFAULT,
-            array(
-                'cost' => 4,
-                'salt' => 'CostAndSaltForceRehash',
-            )
-        );
         $finalValidatorRehash = password_hash($this->plainTextPassword, PASSWORD_DEFAULT);
 
         $validResult = new ValidationResult(
@@ -84,7 +76,7 @@ class KarptoniteRehashUpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
 
         $this->decoratedValidator->expects($this->once())
             ->method('isValid')
-            ->with($this->plainTextPassword, $upgradeValidatorRehash, $this->legacySalt)
+            ->with($this->plainTextPassword, $this->isType('string'), $this->legacySalt)
             ->will($this->returnValue($validResult));
 
         $result = $this->decorator->isValid(
@@ -100,8 +92,8 @@ class KarptoniteRehashUpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
         );
 
         // Final rehashed password is a valid hash
-        $this->assertTrue(
-            password_verify($this->plainTextPassword, $result->getPassword())
+        $this->assertFalse(
+			password_needs_rehash($result->getPassword(), PASSWORD_DEFAULT)
         );
     }
 

--- a/tests/JeremyKendall/Password/Tests/Decorator/KarptoniteRehashUpgradeDecoratorTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/KarptoniteRehashUpgradeDecoratorTest.php
@@ -93,7 +93,7 @@ class KarptoniteRehashUpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
 
         // Final rehashed password is a valid hash
         $this->assertFalse(
-			password_needs_rehash($result->getPassword(), PASSWORD_DEFAULT)
+            password_needs_rehash($result->getPassword(), PASSWORD_DEFAULT)
         );
     }
 

--- a/tests/JeremyKendall/Password/Tests/Decorator/StorageDecoratorTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/StorageDecoratorTest.php
@@ -83,4 +83,13 @@ class StorageDecoratorTest extends \PHPUnit_Framework_TestCase
 
         $result = $this->decorator->isValid('password', 'passwordHash');
     }
+
+	public function testSetForceRehash()
+	{
+		$this->decoratedValidator->expects($this->once())
+			->method("setForceRehash")
+			->with(true);
+
+		$this->decorator->setForceRehash(true);
+	}
 }

--- a/tests/JeremyKendall/Password/Tests/Decorator/StorageDecoratorTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/StorageDecoratorTest.php
@@ -84,12 +84,12 @@ class StorageDecoratorTest extends \PHPUnit_Framework_TestCase
         $result = $this->decorator->isValid('password', 'passwordHash');
     }
 
-	public function testSetForceRehash()
-	{
-		$this->decoratedValidator->expects($this->once())
-			->method("setForceRehash")
-			->with(true);
+    public function testSetForceRehash()
+    {
+        $this->decoratedValidator->expects($this->once())
+            ->method("setForceRehash")
+            ->with(true);
 
-		$this->decorator->setForceRehash(true);
-	}
+        $this->decorator->setForceRehash(true);
+    }
 }

--- a/tests/JeremyKendall/Password/Tests/Decorator/UpgradeDecoratorTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/UpgradeDecoratorTest.php
@@ -139,4 +139,13 @@ class UpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
         $this->decorator->setOptions(array('cost' => '11'));
         $this->assertEquals(array('cost' => '11'), $this->decorator->getOptions());
     }
+
+	public function testSetForceRehash()
+	{
+		$this->decoratedValidator->expects($this->once())
+			->method("setForceRehash")
+			->with(true);
+
+		$this->decorator->setForceRehash(true);
+	}
 }

--- a/tests/JeremyKendall/Password/Tests/Decorator/UpgradeDecoratorTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/UpgradeDecoratorTest.php
@@ -46,10 +46,6 @@ class UpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
     {
         $password = 'password';
         $passwordHash = hash('sha512', $password);
-        $upgradeRehash = password_hash($password, PASSWORD_DEFAULT, array(
-            'cost' => 4,
-            'salt' => 'CostAndSaltForceRehash',
-        ));
 
         $validatorRehash = password_hash($password, PASSWORD_DEFAULT);
 
@@ -60,7 +56,7 @@ class UpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
 
         $this->decoratedValidator->expects($this->once())
             ->method('isValid')
-            ->with($password, $upgradeRehash)
+            ->with($password, $this->isType('string'))
             ->will($this->returnValue($result));
 
         $result = $this->decorator->isValid($password, $passwordHash);
@@ -71,7 +67,7 @@ class UpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
             $result->getCode()
         );
         // Rehashed password is a valid hash
-        $this->assertTrue(password_verify($password, $result->getPassword()));
+        $this->assertFalse(password_needs_rehash($result->getPassword(), PASSWORD_DEFAULT));
     }
 
     public function testLegacyPasswordInvalidDecoratedValidatorTakesOver()

--- a/tests/JeremyKendall/Password/Tests/Decorator/UpgradeDecoratorTest.php
+++ b/tests/JeremyKendall/Password/Tests/Decorator/UpgradeDecoratorTest.php
@@ -140,12 +140,12 @@ class UpgradeDecoratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('cost' => '11'), $this->decorator->getOptions());
     }
 
-	public function testSetForceRehash()
-	{
-		$this->decoratedValidator->expects($this->once())
-			->method("setForceRehash")
-			->with(true);
+    public function testSetForceRehash()
+    {
+        $this->decoratedValidator->expects($this->once())
+            ->method("setForceRehash")
+            ->with(true);
 
-		$this->decorator->setForceRehash(true);
-	}
+        $this->decorator->setForceRehash(true);
+    }
 }

--- a/tests/JeremyKendall/Password/Tests/PasswordValidatorTest.php
+++ b/tests/JeremyKendall/Password/Tests/PasswordValidatorTest.php
@@ -92,4 +92,11 @@ class PasswordValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->setOptions(array('cost' => '11'));
         $this->assertEquals(array('cost' => '11'), $this->validator->getOptions());
     }
+
+	public function testGetSetForceRehash()
+	{
+		$this->assertFalse($this->validator->getForceRehash());
+		$this->validator->setForceRehash(true);
+		$this->assertTrue($this->validator->getForceRehash());
+	}
 }

--- a/tests/JeremyKendall/Password/Tests/PasswordValidatorTest.php
+++ b/tests/JeremyKendall/Password/Tests/PasswordValidatorTest.php
@@ -93,10 +93,10 @@ class PasswordValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('cost' => '11'), $this->validator->getOptions());
     }
 
-	public function testGetSetForceRehash()
-	{
-		$this->assertFalse($this->validator->getForceRehash());
-		$this->validator->setForceRehash(true);
-		$this->assertTrue($this->validator->getForceRehash());
-	}
+    public function testGetSetForceRehash()
+    {
+        $this->assertFalse($this->validator->getForceRehash());
+        $this->validator->setForceRehash(true);
+        $this->assertTrue($this->validator->getForceRehash());
+    }
 }


### PR DESCRIPTION
This attempts to address #16.

As discussed in that issue and [on this commit](https://github.com/garethellis36/password-validator/commit/58075ce2cef15adda11535c387cc1871803484b6), the 'salt' option must be removed from `password_hash()` in `UpgradeDecorator` in order for PHP7 to not emit warnings.

However, without further work re-hashing in `PasswordValidator` does not work without the salt. This PR uses a "slightly naughty" workaround by telling `PasswordValidator` to force a rehash.